### PR TITLE
fix: prescribed displacement editing and inline unit conversions

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -118,6 +118,20 @@ body,
   }
 }
 
+input.inline-edit:disabled {
+  background: #f5f5f5;
+  color: rgba(0, 0, 0, 0.38);
+  cursor: not-allowed;
+}
+
+.inline-edit-group.disabled {
+  .input-before,
+  .input-after {
+    color: rgba(0, 0, 0, 0.38);
+    background: #f5f5f5;
+  }
+}
+
 .hinges .v-selection-control--density-compact {
   height: 20px !important;
   width: 20px !important;

--- a/src/components/BottomBar.vue
+++ b/src/components/BottomBar.vue
@@ -622,7 +622,7 @@
                       'values',
                       4,
                       $event.target as HTMLInputElement,
-                      appStore.convertInverseForce
+                      appStore.convertInverseMoment
                     )
                   "
                 />
@@ -631,35 +631,62 @@
             </div>
 
             <div v-if="item.type === 'prescribed'" class="d-flex">
-              <div class="inline-edit-group load mr-2" style="width: 128px">
+              <div
+                class="inline-edit-group load mr-2"
+                :class="{ disabled: !isDofSupported(item.target, DofID.Dx) }"
+                style="width: 128px"
+              >
                 <label class="input-before">D<sub>x</sub></label>
                 <input
-                  :value="item.ref.prescribedValues[0]"
+                  :value="appStore.convertLength(item.ref.prescribedValues[0])"
                   class="inline-edit"
+                  :disabled="!isDofSupported(item.target, DofID.Dx)"
                   @keydown="checkNumber($event)"
                   @change="
-                    changeSetArrayItem(item.ref, 'prescribedValues', 0, $event.target as HTMLInputElement, (v) => v)
+                    changeSetArrayItem(
+                      item.ref,
+                      'prescribedValues',
+                      0,
+                      $event.target as HTMLInputElement,
+                      appStore.convertInverseLength
+                    )
                   "
                 />
                 <div class="input-after" v-html="formatMeasureAsHTML(appStore.units.Length)"></div>
               </div>
-              <div class="inline-edit-group load mr-2" style="width: 128px">
+              <div
+                class="inline-edit-group load mr-2"
+                :class="{ disabled: !isDofSupported(item.target, DofID.Dz) }"
+                style="width: 128px"
+              >
                 <span class="input-before">D<sub>z</sub></span>
                 <input
-                  :value="item.ref.prescribedValues[2]"
+                  :value="appStore.convertLength(item.ref.prescribedValues[2])"
                   class="inline-edit"
+                  :disabled="!isDofSupported(item.target, DofID.Dz)"
                   @keydown="checkNumber($event)"
                   @change="
-                    changeSetArrayItem(item.ref, 'prescribedValues', 2, $event.target as HTMLInputElement, (v) => v)
+                    changeSetArrayItem(
+                      item.ref,
+                      'prescribedValues',
+                      2,
+                      $event.target as HTMLInputElement,
+                      appStore.convertInverseLength
+                    )
                   "
                 />
                 <div class="input-after" v-html="formatMeasureAsHTML(appStore.units.Length)"></div>
               </div>
-              <div class="inline-edit-group load" style="width: 128px">
+              <div
+                class="inline-edit-group load"
+                :class="{ disabled: !isDofSupported(item.target, DofID.Ry) }"
+                style="width: 128px"
+              >
                 <span class="input-before">R<sub>y</sub></span>
                 <input
                   :value="item.ref.prescribedValues[4]"
                   class="inline-edit"
+                  :disabled="!isDofSupported(item.target, DofID.Ry)"
                   @keydown="checkNumber($event)"
                   @change="
                     changeSetArrayItem(item.ref, 'prescribedValues', 4, $event.target as HTMLInputElement, (v) => v)
@@ -1683,6 +1710,11 @@ const loads = computed(() => {
 
   return display;
 });
+
+/** A displacement can only be prescribed in a DOF that is supported (constrained) at the target node. */
+const isDofSupported = (target: number, dof: DofID) => {
+  return projStore.solver.domain.nodes.get(target)?.bcs.has(dof) ?? false;
+};
 
 const materials = computed(() => {
   const items = useProjectStore().solver.domain.materials.values();

--- a/src/components/ContextMenuNodalLoad.vue
+++ b/src/components/ContextMenuNodalLoad.vue
@@ -1,43 +1,51 @@
 <script setup lang="ts">
 import { openModal } from 'jenesius-vue-modal';
 import EditNodalLoadDialog from './dialogs/EditNodalLoad.vue';
-import { deleteNodalLoad } from '@/utils';
+import { deleteNodalLoad, deletePrescribedDisplacement } from '@/utils';
 import { useProjectStore } from '@/store/project';
 import { computed } from 'vue';
 
 const projectStore = useProjectStore();
 
-const load = computed(() => {
-  return projectStore.solver.loadCases[0].nodalLoadList[projectStore.selection.label];
+/** The same menu serves nodal forces and prescribed displacements - they only differ in the list they live in. */
+const isPrescribed = computed(() => projectStore.selection.type === 'prescribedbc-load');
+
+const loadIndex = computed(() => {
+  if (projectStore.selection.label === null) return null;
+
+  const index = Number(projectStore.selection.label);
+  return Number.isNaN(index) ? null : index;
 });
 
+const editNodalLoad = () => {
+  if (loadIndex.value === null) return;
+
+  openModal(EditNodalLoadDialog, {
+    index: loadIndex.value,
+    type: isPrescribed.value ? 'displacement' : 'force',
+  });
+  projectStore.selection.type = null;
+};
+
 const removeNodalLoad = () => {
-  if (projectStore.selection.label === null) return;
+  if (loadIndex.value === null) return;
 
-  const nodalIndex = Number(projectStore.selection.label);
-  if (Number.isNaN(nodalIndex)) return;
+  const loadCase = projectStore.solver.loadCases[0];
 
-  const selectedLoad = projectStore.solver.loadCases[0].nodalLoadList[nodalIndex];
-  if (!selectedLoad) return;
+  if (isPrescribed.value) {
+    const prescribed = loadCase.prescribedBC[loadIndex.value];
+    if (prescribed) deletePrescribedDisplacement(prescribed);
+    return;
+  }
 
-  const elementLoadCount = projectStore.solver.loadCases[0].elementLoadList.length;
-  const prescribedCount = projectStore.solver.loadCases[0].prescribedBC.length;
-  const aggregatedIndex = elementLoadCount + prescribedCount + nodalIndex;
-
-  deleteNodalLoad(selectedLoad, aggregatedIndex);
+  const nodalLoad = loadCase.nodalLoadList[loadIndex.value];
+  if (nodalLoad) deleteNodalLoad(nodalLoad);
 };
 </script>
 
 <template>
   <v-list density="compact" class="py-0">
-    <v-list-item
-      link
-      class="text-body-2"
-      @click="
-        openModal(EditNodalLoadDialog, { index: projectStore.selection.label });
-        projectStore.selection.type = null;
-      "
-    >
+    <v-list-item link class="text-body-2" @click="editNodalLoad">
       <template #prepend>
         <div class="pr-2"><v-icon size="16" icon="mdi-pencil" /></div>
       </template>

--- a/src/components/SVGViewer.vue
+++ b/src/components/SVGViewer.vue
@@ -2356,7 +2356,9 @@ defineExpose({ centerContent, fitContent });
         <ContextMenuNode v-if="projectStore.selection.type === 'node'"></ContextMenuNode>
         <ContextMenuElement v-if="projectStore.selection.type === 'element'"></ContextMenuElement>
         <ContextMenuElementLoad v-if="projectStore.selection.type === 'element-load'"></ContextMenuElementLoad>
-        <ContextMenuNodalLoad v-if="projectStore.selection.type === 'nodal-load'"></ContextMenuNodalLoad>
+        <ContextMenuNodalLoad
+          v-if="['nodal-load', 'prescribedbc-load'].includes(projectStore.selection.type)"
+        ></ContextMenuNodalLoad>
         <ContextMenuDimension v-if="projectStore.selection.type === 'dimension'"></ContextMenuDimension>
         <!-- <ContextMenuNodalLoad v-if="projectStore.selection.type === 'nodal-load'"></ContextMenuNodalLoad>
         <ContextMenuElementLoad v-if="projectStore.selection.type === 'element-load'"></ContextMenuElementLoad> -->

--- a/src/components/dialogs/AddNodalLoad.vue
+++ b/src/components/dialogs/AddNodalLoad.vue
@@ -45,7 +45,7 @@
                       hide-details="auto"
                       :rules="numberRules"
                       :suffix="mainUnits"
-                      :disabled="loadType === 'displacement' && !nodeBcs.has(0)"
+                      :disabled="loadType === 'displacement' && !nodeBcs.has(DofID.Dx)"
                       @keydown="checkNumber($event)"
                     ></v-text-field>
                   </v-col>
@@ -57,7 +57,7 @@
                       hide-details="auto"
                       :rules="numberRules"
                       :suffix="mainUnits"
-                      :disabled="loadType === 'displacement' && !nodeBcs.has(2)"
+                      :disabled="loadType === 'displacement' && !nodeBcs.has(DofID.Dz)"
                       @keydown="checkNumber($event)"
                     ></v-text-field>
                   </v-col>
@@ -69,7 +69,7 @@
                       hide-details="auto"
                       :rules="numberRules"
                       :suffix="`${momentUnits}`"
-                      :disabled="loadType === 'displacement' && !nodeBcs.has(4)"
+                      :disabled="loadType === 'displacement' && !nodeBcs.has(DofID.Ry)"
                       @keydown="checkNumber($event)"
                     >
                     </v-text-field>

--- a/src/components/dialogs/EditNodalLoad.vue
+++ b/src/components/dialogs/EditNodalLoad.vue
@@ -34,9 +34,7 @@
                       hide-details="auto"
                       :rules="numberRules"
                       :suffix="mainUnits"
-                      :disabled="
-                        loadType === 'displacement' && !projectStore.solver.domain.nodes.get(loadNodeId).bcs.has(0)
-                      "
+                      :disabled="loadType === 'displacement' && !nodeBcs.has(DofID.Dx)"
                       @keydown="checkNumber($event)"
                     ></v-text-field>
                   </v-col>
@@ -48,9 +46,7 @@
                       hide-details="auto"
                       :rules="numberRules"
                       :suffix="mainUnits"
-                      :disabled="
-                        loadType === 'displacement' && !projectStore.solver.domain.nodes.get(loadNodeId).bcs.has(2)
-                      "
+                      :disabled="loadType === 'displacement' && !nodeBcs.has(DofID.Dz)"
                       @keydown="checkNumber($event)"
                     ></v-text-field>
                   </v-col>
@@ -62,9 +58,7 @@
                       hide-details="auto"
                       :rules="numberRules"
                       :suffix="`${momentUnits}`"
-                      :disabled="
-                        loadType === 'displacement' && !projectStore.solver.domain.nodes.get(loadNodeId).bcs.has(4)
-                      "
+                      :disabled="loadType === 'displacement' && !nodeBcs.has(DofID.Ry)"
                       @keydown="checkNumber($event)"
                     >
                     </v-text-field>
@@ -195,4 +189,7 @@ const loadNodeId = computed(() => {
 
   return useProjectStore().solver.loadCases[0].nodalLoadList[props.index].target;
 });
+
+/** DOFs supported (constrained) at the target node - only those can carry a prescribed displacement. */
+const nodeBcs = computed<Set<number>>(() => projectStore.solver.domain.nodes.get(loadNodeId.value)?.bcs ?? new Set());
 </script>

--- a/src/tests/inlineEdit.test.ts
+++ b/src/tests/inlineEdit.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { createApp, h } from 'vue';
+import { changeItem, changeSetArrayItem } from '../utils';
+
+/** Renders an input bound with `:value`, exactly like the inline fields in the bottom bar. */
+const renderBoundInput = (displayValue: string) => {
+  const host = document.createElement('div');
+  createApp({
+    render: () => h('input', { value: displayValue }),
+  }).mount(host);
+
+  return host.querySelector('input') as HTMLInputElement;
+};
+
+describe('inline edit fields', () => {
+  it('restores the displayed value when an array entry is invalid', () => {
+    // 1500 N stored, shown as 1.5 kN
+    const item = { values: [1500] };
+    const el = renderBoundInput('1.5');
+
+    el.value = 'not a number';
+    changeSetArrayItem(item, 'values', 0, el, (v) => v * 1000);
+
+    expect(el.value).toBe('1.5');
+    expect(item.values[0]).toBe(1500);
+  });
+
+  it('restores the displayed value when a property is invalid', () => {
+    // 2.1e11 Pa stored, shown as 210000 MPa
+    const item = { e: 2.1e11 };
+    const el = renderBoundInput('210000');
+
+    el.value = '-';
+    changeItem(item, 'e', el, (v) => v * 1e6);
+
+    expect(el.value).toBe('210000');
+    expect(item.e).toBe(2.1e11);
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -466,6 +466,18 @@ export const swapNodes = (el: Beam2D) => {
   solve();
 };
 
+/**
+ * Puts back the value Vue last rendered into the input. Inline fields show unit converted (and often
+ * formatted) values, so rejecting an invalid entry must not write the raw model value into them.
+ * The rendered value is kept by the runtime as `_value` when the input is bound with `:value`;
+ * the model value is only a fallback for inputs that are not.
+ */
+const restoreRenderedValue = (el: HTMLInputElement, modelValue: unknown) => {
+  const rendered = (el as HTMLInputElement & { _value?: unknown })._value;
+
+  el.value = String(rendered ?? modelValue ?? '');
+};
+
 export const changeSetArrayItem = (
   item: unknown,
   set: string,
@@ -476,7 +488,7 @@ export const changeSetArrayItem = (
   if (el.value === '') el.value = '0';
 
   const val = parseFloat(el.value.replace(/\s/g, '').replace(',', '.'));
-  if (!Number.isFinite(val)) return (el.value = item[set][value]);
+  if (!Number.isFinite(val)) return restoreRenderedValue(el, item[set][value]);
 
   executeModelMutationWithUndo(() => {
     setUnsolved();
@@ -519,7 +531,7 @@ export const changeItem = (item: object, value: string, el?: HTMLInputElement, f
   if (el.value === '') el.value = '0';
 
   const val = parseFloat(el.value.replace(/\s/g, '').replace(',', '.'));
-  if (!Number.isFinite(val)) return (el.value = item[value]);
+  if (!Number.isFinite(val)) return restoreRenderedValue(el, item[value]);
 
   executeModelMutationWithUndo(() => {
     setUnsolved();


### PR DESCRIPTION
## What

Four bug fixes around editing prescribed displacements and unit-converted inline fields.

### Prescribed displacement context menu was empty

Clicking a prescribed displacement in the canvas sets `selection.type = 'prescribedbc-load'`,
but the selection tooltip only rendered a menu for `'nodal-load'` — so the panel showed the
load name with no Edit or Delete entry.

`ContextMenuNodalLoad` now serves both selection types: Edit opens `EditNodalLoad` with
`type: 'displacement'` (reading from `prescribedBC` instead of `nodalLoadList`), and Delete
dispatches to `deletePrescribedDisplacement`. The delete helpers remove by identity and ignore
their index argument, so the aggregated-index arithmetic — which was wrong for the prescribed
case anyway — is gone.

### Bottom bar ignored the node's supports

The Add and Edit dialogs disable the DOFs a node has no support in, since only supported DOFs
can carry a prescribed displacement. The bottom bar let all three be edited. It now applies the
same rule via a shared `isDofSupported(target, dof)` check, with styling for disabled inline
fields (these are plain `<input>`s, not Vuetify fields, so they need their own disabled state).

### Prescribed Dx/Dz were not unit-converted

The bottom bar displayed and stored `prescribedValues[0]`/`[2]` raw while labelling them with the
selected length unit, so the bar disagreed with the dialogs, the SVG label, and the hover tooltip
— all of which convert. `Ry` is left alone: rotations are radians everywhere and `units.Angle`
is not user-selectable.

### Nodal load `My` used the wrong converter

The field displayed `convertMoment` but wrote back through `convertInverseForce`. With the
defaults (kN, kN·m) the two cancel, so it looked correct — but moment units are configured
separately from force units, so selecting N as the force unit would scale every edited moment
by 1000.

### Invalid inline edits reverted to the raw model value

`changeItem` and `changeSetArrayItem` restored `item[key]` when input could not be parsed —
the SI value, not the converted and formatted one the user was looking at. Typing `-` into a
material's E showed `210000000000` instead of `210000`.

Both helpers now restore the value Vue last rendered into the input (`el._value`, set by the
runtime for any `:value` binding), falling back to the model value for unbound inputs. This
fixes every inline field at once: node coordinates, nodal loads, prescribed displacements,
element loads, materials, and cross sections — including the ones formatted with `float2String`
or `formatScientificNumber`, which previously lost their formatting on a rejected edit.

## Testing

`src/tests/inlineEdit.test.ts` mounts a real Vue-bound input, enters invalid text, and asserts
the field reverts to the displayed value with the model untouched. Verified the tests fail
against the previous behaviour (`expected '1500' to be '1.5'`).

`npm run test:run` — 116 passed. `npm run lint` reports no new problems.
