### PR TITLE
fix: convert distributed load intensities by the length unit

### DIFF
--- a/src/components/BottomBar.vue
+++ b/src/components/BottomBar.vue
@@ -676,7 +676,7 @@
                 <div class="inline-edit-group load mr-2">
                   <span class="input-before" v-html="'f<sub>x1</sub>'"></span>
                   <input
-                    :value="appStore.convertForce(item.ref.startValues[0])"
+                    :value="appStore.convertForceDistance(item.ref.startValues[0])"
                     class="inline-edit"
                     style="width: 60px"
                     @keydown="checkNumber($event)"
@@ -686,7 +686,7 @@
                         'startValues',
                         0,
                         $event.target as HTMLInputElement,
-                        appStore.convertInverseForce
+                        appStore.convertInverseForceDistance
                       )
                     "
                   />
@@ -695,7 +695,7 @@
                 <div class="inline-edit-group load mr-2">
                   <span class="input-before" v-html="'f<sub>x2</sub>'"></span>
                   <input
-                    :value="appStore.convertForce(item.ref.endValues[0])"
+                    :value="appStore.convertForceDistance(item.ref.endValues[0])"
                     class="inline-edit"
                     style="width: 60px"
                     @keydown="checkNumber($event)"
@@ -705,7 +705,7 @@
                         'endValues',
                         0,
                         $event.target as HTMLInputElement,
-                        appStore.convertInverseForce
+                        appStore.convertInverseForceDistance
                       )
                     "
                   />
@@ -714,7 +714,7 @@
                 <div class="inline-edit-group load mr-2">
                   <span class="input-before" v-html="'f<sub>z1</sub>'"></span>
                   <input
-                    :value="appStore.convertForce(item.ref.startValues[1])"
+                    :value="appStore.convertForceDistance(item.ref.startValues[1])"
                     class="inline-edit"
                     style="width: 60px"
                     @keydown="checkNumber($event)"
@@ -724,7 +724,7 @@
                         'startValues',
                         1,
                         $event.target as HTMLInputElement,
-                        appStore.convertInverseForce
+                        appStore.convertInverseForceDistance
                       )
                     "
                   />
@@ -733,7 +733,7 @@
                 <div class="inline-edit-group load mr-2">
                   <span class="input-before" v-html="'f<sub>z2</sub>'"></span>
                   <input
-                    :value="appStore.convertForce(item.ref.endValues[1])"
+                    :value="appStore.convertForceDistance(item.ref.endValues[1])"
                     class="inline-edit"
                     style="width: 60px"
                     @keydown="checkNumber($event)"
@@ -743,7 +743,7 @@
                         'endValues',
                         1,
                         $event.target as HTMLInputElement,
-                        appStore.convertInverseForce
+                        appStore.convertInverseForceDistance
                       )
                     "
                   />
@@ -760,11 +760,7 @@
                     v-html="$t('loads.temperatureDeltaTs')"
                   ></span>
                   <input
-                    :value="
-                      loadType(item.ref) !== 'temperature'
-                        ? appStore.convertForce(item.ref.values[0])
-                        : appStore.convertTemperature(item.ref.values[0])
-                    "
+                    :value="elementLoadDisplayValue(item.ref, 0)"
                     class="inline-edit"
                     style="width: 60px"
                     @keydown="checkNumber($event)"
@@ -774,9 +770,7 @@
                         'values',
                         0,
                         $event.target as HTMLInputElement,
-                        loadType(item.ref) !== 'temperature'
-                          ? appStore.convertInverseForce
-                          : appStore.convertInverseTemperature
+                        elementLoadInverseConverter(item.ref)
                       )
                     "
                   />
@@ -805,11 +799,7 @@
                     v-html="$t('loads.temperatureDeltaTbt')"
                   ></span>
                   <input
-                    :value="
-                      loadType(item.ref) !== 'temperature'
-                        ? appStore.convertForce(item.ref.values[1])
-                        : appStore.convertTemperature(item.ref.values[1])
-                    "
+                    :value="elementLoadDisplayValue(item.ref, 1)"
                     class="inline-edit"
                     style="width: 60px"
                     @keydown="checkNumber($event)"
@@ -819,9 +809,7 @@
                         'values',
                         1,
                         $event.target as HTMLInputElement,
-                        loadType(item.ref) !== 'temperature'
-                          ? appStore.convertInverseForce
-                          : appStore.convertInverseTemperature
+                        elementLoadInverseConverter(item.ref)
                       )
                     "
                   />
@@ -1504,6 +1492,7 @@ import {
   BeamElementUniformEdgeLoad,
   BeamElementTrapezoidalEdgeLoad,
   BeamConcentratedLoad,
+  BeamTemperatureLoad,
   NodalLoad,
 } from 'ts-fem';
 
@@ -1684,6 +1673,30 @@ const loads = computed(() => {
   return display;
 });
 
+type ElementLoadValues = BeamElementUniformEdgeLoad | BeamConcentratedLoad | BeamTemperatureLoad;
+
+/**
+ * The same two inputs serve uniform, concentrated and temperature loads, and each carries a
+ * different quantity: an intensity (force per length), a force, and a temperature difference.
+ */
+const elementLoadDisplayValue = (load: ElementLoadValues, index: number) => {
+  const type = loadType(load);
+
+  if (type === 'temperature') return appStore.convertTemperature(load.values[index]);
+  if (type === 'udl') return appStore.convertForceDistance(load.values[index]);
+
+  return appStore.convertForce(load.values[index]);
+};
+
+const elementLoadInverseConverter = (load: ElementLoadValues) => {
+  const type = loadType(load);
+
+  if (type === 'temperature') return appStore.convertInverseTemperature;
+  if (type === 'udl') return appStore.convertInverseForceDistance;
+
+  return appStore.convertInverseForce;
+};
+
 const materials = computed(() => {
   const items = useProjectStore().solver.domain.materials.values();
   const display: Material[] = [];
@@ -1764,20 +1777,20 @@ const formatElementLoadsAtElement = (item: Beam2D): [number, string][] => {
       const startFz = nl.ref.startValues[1];
       const endFz = nl.ref.endValues[1];
       if (Math.abs(startFx) > 1e-12 || Math.abs(endFx) > 1e-12) {
-        const startText = appStore.convertForce(startFx);
-        const endText = appStore.convertForce(endFx);
+        const startText = appStore.convertForceDistance(startFx);
+        const endText = appStore.convertForceDistance(endFx);
         tmp.push(`${ff}<sub>x</sub> = ${startText} → ${endText}`);
       }
       if (Math.abs(startFz) > 1e-12 || Math.abs(endFz) > 1e-12) {
-        const startText = appStore.convertForce(startFz);
-        const endText = appStore.convertForce(endFz);
+        const startText = appStore.convertForceDistance(startFz);
+        const endText = appStore.convertForceDistance(endFz);
         tmp.push(`${ff}<sub>z</sub> = ${startText} → ${endText}`);
       }
     } else if ('values' in nl.ref) {
-      if (Math.abs(nl.ref.values[0]) > 1e-12)
-        tmp.push(ff + '<sub>x</sub> = ' + appStore.convertForce(nl.ref.values[0]));
-      if (Math.abs(nl.ref.values[1]) > 1e-12)
-        tmp.push(ff + '<sub>z</sub> = ' + appStore.convertForce(nl.ref.values[1]));
+      const convert = nl.type === 'udl' ? appStore.convertForceDistance : appStore.convertForce;
+
+      if (Math.abs(nl.ref.values[0]) > 1e-12) tmp.push(ff + '<sub>x</sub> = ' + convert(nl.ref.values[0]));
+      if (Math.abs(nl.ref.values[1]) > 1e-12) tmp.push(ff + '<sub>z</sub> = ' + convert(nl.ref.values[1]));
     }
     return [nl.index, tmp.join(', ')];
   });

--- a/src/components/ElementLoadPreview.vue
+++ b/src/components/ElementLoadPreview.vue
@@ -119,6 +119,7 @@ watch(
       :support-size="0.75"
       :number-format="appStore.numberFormatter"
       :convert-force="appStore.convertForce"
+      :convert-force-distance="appStore.convertForceDistance"
       :convert-moment="appStore.convertMoment"
       :convert-length="appStore.convertLength"
       :colors="viewerStore.colors"

--- a/src/components/SVGElementViewer.vue
+++ b/src/components/SVGElementViewer.vue
@@ -78,6 +78,7 @@ const props = withDefaults(
     };
     supportSize?: number;
     convertForce?: (value: number) => number;
+    convertForceDistance?: (value: number) => number;
     convertMoment?: (value: number) => number;
     convertLength?: (value: number) => number;
     resultLabelMode?: 'axis' | 'horizontal';
@@ -124,6 +125,7 @@ const props = withDefaults(
     },
     supportSize: 1,
     convertForce: (v) => v,
+    convertForceDistance: (v) => v,
     convertMoment: (v) => v,
     convertLength: (v) => v,
     resultLabelMode: 'axis',
@@ -327,7 +329,7 @@ defineExpose({ centerContent, fitContent });
                   :data-element-load-id="index"
                   :eload="eload"
                   :scale="scale"
-                  :convert-force="props.convertForce"
+                  :convert-force-distance="props.convertForceDistance"
                   :font-size="props.fontSize"
                 />
                 <SVGElementTemperatureLoad

--- a/src/components/SVGViewer.vue
+++ b/src/components/SVGViewer.vue
@@ -489,7 +489,10 @@ const onElementLoadHover = (e: MouseEvent, el: BeamElementLoad) => {
   else if (el instanceof BeamConcentratedLoad) lt = 'loadType.concentrated';
   else if (el instanceof BeamTemperatureLoad) lt = 'loadType.temperature';
   const ff = isDistributed ? 'f' : 'F';
-  const uu = isDistributed ? `${appStore.units.Force}/${appStore.units.Length}` : `${appStore.units.Force}`;
+  // A distributed load is an intensity, a concentrated one a force; both parts of the unit count.
+  const convertIntensity = isDistributed ? appStore.convertForceDistance : appStore.convertForce;
+  let uu = isDistributed ? appStore.units.ForceDistance : appStore.units.Force;
+  if (el instanceof BeamTemperatureLoad) uu = appStore.units.Temperature;
 
   tooltipContent.innerHTML = `<strong>${t(lt)}</strong><br>`;
 
@@ -503,23 +506,23 @@ const onElementLoadHover = (e: MouseEvent, el: BeamElementLoad) => {
     }
   } else if (el instanceof BeamElementTrapezoidalEdgeLoad) {
     if (Math.abs(el.startValues[0]) > 1e-32 || Math.abs(el.endValues[0]) > 1e-32) {
-      tooltipContent.innerHTML += `${ff}<sub>x</sub> = ${appStore.convertForce(el.startValues[0])} → ${appStore.convertForce(
+      tooltipContent.innerHTML += `${ff}<sub>x</sub> = ${convertIntensity(el.startValues[0])} → ${convertIntensity(
         el.endValues[0]
       )} ${uu}<br>`;
     }
 
     if (Math.abs(el.startValues[1]) > 1e-32 || Math.abs(el.endValues[1]) > 1e-32) {
-      tooltipContent.innerHTML += `${ff}<sub>z</sub> = ${appStore.convertForce(el.startValues[1])} → ${appStore.convertForce(
+      tooltipContent.innerHTML += `${ff}<sub>z</sub> = ${convertIntensity(el.startValues[1])} → ${convertIntensity(
         el.endValues[1]
       )} ${uu}`;
     }
   } else if (el instanceof BeamElementUniformEdgeLoad || el instanceof BeamConcentratedLoad) {
     if (Math.abs(el.values[0]) > 1e-32) {
-      tooltipContent.innerHTML += `${ff}<sub>x</sub> = ${appStore.convertForce(el.values[0])} ${uu}<br>`;
+      tooltipContent.innerHTML += `${ff}<sub>x</sub> = ${convertIntensity(el.values[0])} ${uu}<br>`;
     }
 
     if (Math.abs(el.values[1]) > 1e-32) {
-      tooltipContent.innerHTML += `${ff}<sub>z</sub> = ${appStore.convertForce(el.values[1])} ${uu}`;
+      tooltipContent.innerHTML += `${ff}<sub>z</sub> = ${convertIntensity(el.values[1])} ${uu}`;
     }
   }
 
@@ -550,7 +553,7 @@ const onNodalLoadHover = (e: MouseEvent, el: NodalLoad) => {
   }
 
   if (Math.abs(el.values[4]) > 1e-32) {
-    tooltipContent.innerHTML += `M<sub>y</sub> = ${appStore.convertForce(el.values[4])} ${appStore.units.Force}${appStore.units.Length}`;
+    tooltipContent.innerHTML += `M<sub>y</sub> = ${appStore.convertMoment(el.values[4])} ${appStore.units.Moment}`;
   }
 
   tt.style.display = 'block';
@@ -2018,7 +2021,7 @@ defineExpose({ centerContent, fitContent });
                   :data-element-load-id="index"
                   :eload="eload"
                   :scale="scale"
-                  :convert-force="appStore.convertForce"
+                  :convert-force-distance="appStore.convertForceDistance"
                   :font-size="viewerStore.fontSize"
                   :number-format="appStore.numberFormatter"
                   @mousemove="onElementLoadHover($event, eload)"

--- a/src/components/dialogs/AddElementLoad.vue
+++ b/src/components/dialogs/AddElementLoad.vue
@@ -245,7 +245,7 @@ const unitAndLabel = computed(() => {
   let l = 'F';
 
   if (loadType.value === 'udl' || loadType.value === 'trapezoidal') {
-    u += '/m';
+    u = appStore.units.ForceDistance;
     l = 'f';
   }
 
@@ -272,13 +272,17 @@ const loadNodeValueTbt = ref('0.0');
 const elementLoadPos = ref('0.0');
 const elementLCS = ref(true);
 
-const realFx = computed(() => appStore.convertInverseForce(parseFloat2(loadNodeValueFx.value)));
-const realFz = computed(() => appStore.convertInverseForce(parseFloat2(loadNodeValueFz.value)));
+const inverseIntensity = computed(() =>
+  loadType.value === 'udl' ? appStore.convertInverseForceDistance : appStore.convertInverseForce
+);
+
+const realFx = computed(() => inverseIntensity.value(parseFloat2(loadNodeValueFx.value)));
+const realFz = computed(() => inverseIntensity.value(parseFloat2(loadNodeValueFz.value)));
 const realMy = computed(() => appStore.convertInverseMoment(parseFloat2(loadNodeValueMy.value)));
-const realTrapStartFx = computed(() => appStore.convertInverseForce(parseFloat2(loadTrapezoidStartFx.value)));
-const realTrapStartFz = computed(() => appStore.convertInverseForce(parseFloat2(loadTrapezoidStartFz.value)));
-const realTrapEndFx = computed(() => appStore.convertInverseForce(parseFloat2(loadTrapezoidEndFx.value)));
-const realTrapEndFz = computed(() => appStore.convertInverseForce(parseFloat2(loadTrapezoidEndFz.value)));
+const realTrapStartFx = computed(() => appStore.convertInverseForceDistance(parseFloat2(loadTrapezoidStartFx.value)));
+const realTrapStartFz = computed(() => appStore.convertInverseForceDistance(parseFloat2(loadTrapezoidStartFz.value)));
+const realTrapEndFx = computed(() => appStore.convertInverseForceDistance(parseFloat2(loadTrapezoidEndFx.value)));
+const realTrapEndFz = computed(() => appStore.convertInverseForceDistance(parseFloat2(loadTrapezoidEndFz.value)));
 const realDist = computed(() => appStore.convertInverseLength(parseFloat2(elementLoadPos.value)));
 const realTc = computed(() => appStore.convertInverseTemperature(parseFloat2(loadNodeValueTc.value)));
 const realTbt = computed(() => appStore.convertInverseTemperature(parseFloat2(loadNodeValueTbt.value)));

--- a/src/components/dialogs/EditElementLoad.vue
+++ b/src/components/dialogs/EditElementLoad.vue
@@ -245,7 +245,7 @@ const unitAndLabel = computed(() => {
   let l = 'F';
 
   if (loadType.value === 'udl' || loadType.value === 'trapezoidal') {
-    u += '/m';
+    u = appStore.units.ForceDistance;
     l = 'f';
   }
 
@@ -279,13 +279,17 @@ const minMax = (v) => {
   return true;
 };
 
-const realFx = computed(() => appStore.convertInverseForce(parseFloat2(elementNodeValueFx.value)));
-const realFz = computed(() => appStore.convertInverseForce(parseFloat2(elementNodeValueFz.value)));
+const inverseIntensity = computed(() =>
+  loadType.value === 'udl' ? appStore.convertInverseForceDistance : appStore.convertInverseForce
+);
+
+const realFx = computed(() => inverseIntensity.value(parseFloat2(elementNodeValueFx.value)));
+const realFz = computed(() => inverseIntensity.value(parseFloat2(elementNodeValueFz.value)));
 const realMy = computed(() => appStore.convertInverseMoment(parseFloat2(loadNodeValueMy.value)));
-const realTrapStartFx = computed(() => appStore.convertInverseForce(parseFloat2(trapezoidStartFx.value)));
-const realTrapStartFz = computed(() => appStore.convertInverseForce(parseFloat2(trapezoidStartFz.value)));
-const realTrapEndFx = computed(() => appStore.convertInverseForce(parseFloat2(trapezoidEndFx.value)));
-const realTrapEndFz = computed(() => appStore.convertInverseForce(parseFloat2(trapezoidEndFz.value)));
+const realTrapStartFx = computed(() => appStore.convertInverseForceDistance(parseFloat2(trapezoidStartFx.value)));
+const realTrapStartFz = computed(() => appStore.convertInverseForceDistance(parseFloat2(trapezoidStartFz.value)));
+const realTrapEndFx = computed(() => appStore.convertInverseForceDistance(parseFloat2(trapezoidEndFx.value)));
+const realTrapEndFz = computed(() => appStore.convertInverseForceDistance(parseFloat2(trapezoidEndFz.value)));
 const realDist = computed(() => appStore.convertInverseLength(parseFloat2(elementLoadPos.value)));
 const realTc = computed(() => appStore.convertInverseTemperature(parseFloat2(loadNodeValueTc.value)));
 const realTbt = computed(() => appStore.convertInverseTemperature(parseFloat2(loadNodeValueTbt.value)));
@@ -325,8 +329,11 @@ const previewLoad = computed(() => {
 
 onMounted(() => {
   if (load.value instanceof BeamElementUniformEdgeLoad || load.value instanceof BeamConcentratedLoad) {
-    elementNodeValueFx.value = appStore.convertForce(load.value.values[0]).toString();
-    elementNodeValueFz.value = appStore.convertForce(load.value.values[1]).toString();
+    const convert =
+      load.value instanceof BeamElementUniformEdgeLoad ? appStore.convertForceDistance : appStore.convertForce;
+
+    elementNodeValueFx.value = convert(load.value.values[0]).toString();
+    elementNodeValueFz.value = convert(load.value.values[1]).toString();
   }
   if (
     load.value instanceof BeamElementUniformEdgeLoad ||
@@ -337,10 +344,10 @@ onMounted(() => {
   }
 
   if (load.value instanceof BeamElementTrapezoidalEdgeLoad) {
-    trapezoidStartFx.value = appStore.convertForce(load.value.startValues[0]).toString();
-    trapezoidStartFz.value = appStore.convertForce(load.value.startValues[1]).toString();
-    trapezoidEndFx.value = appStore.convertForce(load.value.endValues[0]).toString();
-    trapezoidEndFz.value = appStore.convertForce(load.value.endValues[1]).toString();
+    trapezoidStartFx.value = appStore.convertForceDistance(load.value.startValues[0]).toString();
+    trapezoidStartFz.value = appStore.convertForceDistance(load.value.startValues[1]).toString();
+    trapezoidEndFx.value = appStore.convertForceDistance(load.value.endValues[0]).toString();
+    trapezoidEndFz.value = appStore.convertForceDistance(load.value.endValues[1]).toString();
   }
 
   if (load.value instanceof BeamConcentratedLoad) {

--- a/src/components/svg/ElementLoad.vue
+++ b/src/components/svg/ElementLoad.vue
@@ -9,7 +9,7 @@ const props = withDefaults(
   defineProps<{
     eload: BeamElementUniformEdgeLoad | BeamElementTrapezoidalEdgeLoad;
     scale: number;
-    convertForce: (f: number) => number;
+    convertForceDistance: (f: number) => number;
     fontSize?: number;
     numberFormat?: Intl.NumberFormat;
   }>(),

--- a/src/components/svg/ElementLoad/Trapezoidal.vue
+++ b/src/components/svg/ElementLoad/Trapezoidal.vue
@@ -6,7 +6,7 @@ const props = withDefaults(
   defineProps<{
     eload: BeamElementTrapezoidalEdgeLoad;
     scale: number;
-    convertForce: (f: number) => number;
+    convertForceDistance: (f: number) => number;
     fontSize?: number;
     numberFormat?: Intl.NumberFormat;
   }>(),
@@ -325,7 +325,7 @@ const labelTransforms = computed(() => {
   };
 });
 
-const formatMagnitude = (value: number) => props.numberFormat.format(Math.abs(props.convertForce(value)));
+const formatMagnitude = (value: number) => props.numberFormat.format(Math.abs(props.convertForceDistance(value)));
 
 const fxConstantLabel = computed(() => formatMagnitude(props.eload.startValues[0]));
 const fxStartLabel = computed(() => formatMagnitude(props.eload.startValues[0]));

--- a/src/components/svg/ElementLoad/UDL.vue
+++ b/src/components/svg/ElementLoad/UDL.vue
@@ -6,7 +6,7 @@ const props = withDefaults(
   defineProps<{
     eload: BeamElementUniformEdgeLoad;
     scale: number;
-    convertForce: (f: number) => number;
+    convertForceDistance: (f: number) => number;
     fontSize?: number;
     numberFormat?: Intl.NumberFormat;
   }>(),
@@ -269,7 +269,7 @@ const stackedTransform = computed(() => {
         dominant-baseline="middle"
         :transform="eloadLabels[0]"
       >
-        {{ numberFormat.format(Math.abs(convertForce(eload.values[0]))) }}
+        {{ numberFormat.format(Math.abs(convertForceDistance(eload.values[0]))) }}
       </text>
       <text
         v-if="eload.values[1] !== 0"
@@ -279,7 +279,7 @@ const stackedTransform = computed(() => {
         dominant-baseline="middle"
         :transform="eloadLabels[1]"
       >
-        {{ numberFormat.format(Math.abs(convertForce(eload.values[1]))) }}
+        {{ numberFormat.format(Math.abs(convertForceDistance(eload.values[1]))) }}
       </text>
     </g>
     <polygon

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -128,6 +128,10 @@ export const useAppStore = defineStore(
     const convertInverseForce = (value: number) => _convertInverseForce(value);
     const convertMoment = (value: number) => _convertMoment(value);
     const convertInverseMoment = (value: number) => _convertInverseMoment(value);
+    // Distributed load intensities are a force per length, so both parts of the unit have to be
+    // converted. Length conversion is a pure scale factor, hence dividing by the factor for 1 m.
+    const convertForceDistance = (value: number) => _convertForce(value) / _convertLength(1);
+    const convertInverseForceDistance = (value: number) => _convertInverseForce(value * _convertLength(1));
     const convertTemperature = (value: number) => _convertTemperature(value);
     const convertInverseTemperature = (value: number) => _convertInverseTemperature(value);
 
@@ -226,6 +230,8 @@ export const useAppStore = defineStore(
       convertInverseForce,
       convertMoment,
       convertInverseMoment,
+      convertForceDistance,
+      convertInverseForceDistance,
       convertTemperature,
       convertInverseTemperature,
 

--- a/src/tests/forceDistanceConversion.test.ts
+++ b/src/tests/forceDistanceConversion.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { nextTick } from 'vue';
+import { useAppStore } from '@/store/app';
+
+/**
+ * Distributed load intensities are stored in N/m and shown in the selected force and length
+ * units, so both parts of the unit have to be converted.
+ */
+describe('force per length conversion', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('converts both parts of the unit', async () => {
+    const appStore = useAppStore();
+
+    // defaults: kN/m
+    expect(appStore.convertForceDistance(1000)).toBeCloseTo(1, 9);
+
+    appStore.units.Length = 'mm';
+    await nextTick();
+
+    // 1 kN/m is 0.001 kN/mm
+    expect(appStore.units.ForceDistance).toBe('kN/mm');
+    expect(appStore.convertForceDistance(1000)).toBeCloseTo(0.001, 12);
+  });
+
+  it('converts the force part on its own', async () => {
+    const appStore = useAppStore();
+
+    appStore.units.Force = 'N';
+    await nextTick();
+
+    expect(appStore.units.ForceDistance).toBe('N/m');
+    expect(appStore.convertForceDistance(1000)).toBeCloseTo(1000, 9);
+  });
+
+  it('round trips through the displayed value', async () => {
+    const appStore = useAppStore();
+
+    for (const [force, length] of [
+      ['kN', 'm'],
+      ['kN', 'mm'],
+      ['N', 'cm'],
+      ['kgf', 'mm'],
+    ]) {
+      appStore.units.Force = force;
+      appStore.units.Length = length;
+      await nextTick();
+
+      const stored = 12345.678;
+      const shown = appStore.convertForceDistance(stored);
+
+      expect(appStore.convertInverseForceDistance(shown)).toBeCloseTo(stored, 6);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Element load intensities (UDL, trapezoidal) are stored in N/m but were converted for display with `convertForce` only — the length part of the unit was never applied.

- Display and write-back used the same converter, so values round-trip correctly and nothing was stored wrong. Only the label is off.
- With the default length unit (m) everything agrees, so it shows up only after changing it: a 10 kN/m load still reads `10`, labelled `kN/mm`, where it should read `0.01 kN/mm` — 1000× too large if you trust the label.
- The Add/Edit dialogs escaped it by hardcoding `Force + '/m'`, which matches the number but ignores the length unit setting.

## Approach — please pick

There are two valid fixes, and this PR implements the first:

1. **Convert both parts of the unit** (this PR), so intensities follow the length unit like coordinates, cross-section dimensions and the concentrated load position `d` already do. Downside: small numbers, e.g. `0.01 kN/cm`.
2. **Keep intensities fixed at force/m** and always label them `kN/m`, as the dialogs already do. Smaller change: no converter, just correct the labels in the bottom bar and the tooltip, which today claim `units.ForceDistance` over a per-metre number. Matches how line loads are normally quoted.

I am happy to redo this as option 2 if you prefer — say the word and I'll rework the branch.

## Changes

- **app store:** new `convertForceDistance` / `convertInverseForceDistance` — `convertForce(v) / convertLength(1)` and its inverse. Both parts are pure scale factors, so this is exact.
- **bottom bar:** trapezoidal and uniform inputs, plus the load chips in the elements tab. The shared uniform/concentrated/temperature inputs now pick their converter through two helpers instead of nested ternaries.
- **canvas tooltip:** converter chosen from `isDistributed`, label from `units.ForceDistance`.
- **on-canvas labels:** `convertForce` prop renamed to `convertForceDistance` in `svg/ElementLoad.vue`, `ElementLoad/UDL.vue`, `ElementLoad/Trapezoidal.vue` — they draw nothing else. Plumbed through `SVGElementViewer.vue` and `ElementLoadPreview.vue`.
- **Add/Edit element load dialogs:** converter selected by load type; hardcoded `'/m'` replaced by `units.ForceDistance`.

**Two label bugs** in the same tooltip, same class of mistake:

- temperature loads were labelled with the force unit (`kN`) → `units.Temperature`.
- nodal load `My` used `convertForce` with a `Force`+`Length` label → `convertMoment` with `units.Moment`, as `svg/Node.vue` already does.

## Notes

- Storage stays SI, only presentation changes — no migration.

## Testing

- `src/tests/forceDistanceConversion.test.ts`: both parts converted, force part alone, round trip across four force/length combinations.
- `npm run test:run` 117 passed · `npx vite build` ok · `npm run lint` no new problems.
