### PR TITLE
fix: let the settings dialog scroll on a phone

### DIFF
--- a/src/components/settings/Settings.vue
+++ b/src/components/settings/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="settings-layout fill-height">
+  <div class="settings-layout">
     <div class="settings-shell">
       <div class="settings-sidebar-wrapper">
         <v-sheet class="settings-panel settings-sidebar">
@@ -184,14 +184,54 @@ const resetSettings = () => {
   padding: 24px;
 }
 
+/*
+ * Stacked, the sidebar and the options no longer get a viewport each: on a phone the nav alone can
+ * eat the whole dialog and squeeze the options pane to nothing, with its overflow hidden. So let
+ * the content flow at its natural height and leave the scrolling to the dialog card itself, which
+ * Vuetify already gives `overflow-y: auto`.
+ */
 @media (max-width: 1100px) {
+  .settings-layout {
+    height: auto;
+    overflow: visible;
+  }
+
   .settings-shell {
     flex-direction: column;
+    height: auto;
   }
 
   .settings-sidebar-wrapper {
     flex: 0 0 auto;
     max-width: none;
+    border-right: none;
+    border-bottom: 1px solid rgba(var(--v-border-color), 0.15);
+  }
+
+  .settings-sidebar-wrapper,
+  .settings-content-wrapper,
+  .settings-panel {
+    min-height: auto;
+  }
+
+  .settings-sidebar-scroll,
+  .settings-content-scroll {
+    flex: 0 0 auto;
+    overflow: visible;
+  }
+
+  .settings-content-scroll {
+    padding: 16px;
+  }
+
+  /* The nav is passed on the way to every option, so keep it short */
+  .settings-sidebar-wrapper .v-list-item-subtitle {
+    display: none;
+  }
+
+  .settings-sidebar-wrapper .v-list-item.py-3 {
+    padding-top: 8px !important;
+    padding-bottom: 8px !important;
   }
 }
 </style>


### PR DESCRIPTION
## Problem

The settings dialog is unusable on a phone: the lower options cannot be reached at all.

- Below 1100px the sidebar and the options stack, but the sidebar keeps its full natural height (`flex: 0 0 auto`) and the options pane takes whatever is left of the dialog's `calc(100% - 48px)` — often almost nothing.
- `.settings-layout` is `height: 100%` with `overflow: hidden` above it, so the rest is clipped, and the dialog card has nothing to scroll because the layout is exactly as tall as the card.
- Viewer settings shows it worst: its 256px preview alone can fill the surviving space, leaving the colour pickers unreachable.

## Change

Below the same breakpoint where the panes stack, the nested scrollers are switched off and the content flows at its natural height, leaving the scrolling to the dialog card — which Vuetify already gives `overflow-y: auto`.

- `.settings-layout` → `height: auto; overflow: visible`; the `fill-height` class is dropped from the root element, since `height: 100% !important` cannot be overridden by a media query.
- `.settings-shell` → `height: auto`; both scroll containers → `flex: 0 0 auto; overflow: visible`; the wrappers' `min-height: 0` relaxed to `auto` so nothing is squeezed below its content.
- The sidebar's separator moves from a right border to a bottom one, which is where the edge actually is when stacked.

The two-column layout with its independent scrollers is untouched above 1100px.

## Testing

Manual, on a phone.
