### PR TITLE
feat: set element end hinges from the context menu and the add dialog

### DIFF
--- a/src/components/ContextMenuElement.vue
+++ b/src/components/ContextMenuElement.vue
@@ -7,7 +7,7 @@ import StiffnessMatrix from './StiffnessMatrix.vue';
 import SectionThumbnail from './SectionThumbnail.vue';
 import '@/types/crossSection';
 import { ref, computed, onMounted, watch } from 'vue';
-import { deleteElement, setUnsolved, solve } from '../utils';
+import { deleteElement, setUnsolved, solve, toggleArray } from '../utils';
 
 const projectStore = useProjectStore();
 
@@ -64,6 +64,13 @@ watch([n1, n2], () => {
                 class="menu-select"
                 style="width: 90px"
               ></v-select>
+              <v-checkbox-btn
+                class="hinges px-2"
+                density="compact"
+                :label="$t('elements.hinge')"
+                :model-value="element.hinges[0]"
+                @click="toggleArray(element, 'hinges', 0)"
+              />
             </v-col>
             <v-col>
               <v-select
@@ -77,6 +84,13 @@ watch([n1, n2], () => {
                 class="menu-select"
                 style="width: 90px"
               ></v-select>
+              <v-checkbox-btn
+                class="hinges px-2"
+                density="compact"
+                :label="$t('elements.hinge')"
+                :model-value="element.hinges[1]"
+                @click="toggleArray(element, 'hinges', 1)"
+              />
             </v-col>
           </v-row>
           <v-row no-gutters>
@@ -159,3 +173,11 @@ watch([n1, n2], () => {
     </v-list-item>
   </v-list>
 </template>
+
+<style scoped>
+/* The hinge label reads as a caption of the select above it, so it matches its floating label. */
+.hinges :deep(.v-label) {
+  font-size: 0.75em;
+  opacity: var(--v-medium-emphasis-opacity);
+}
+</style>

--- a/src/components/dialogs/AddElement.vue
+++ b/src/components/dialogs/AddElement.vue
@@ -21,6 +21,12 @@
                   required
                   autofocus
                 />
+                <v-checkbox-btn
+                  v-model="newElementHinges[0]"
+                  class="hinges"
+                  density="compact"
+                  :label="$t('elements.hinge')"
+                />
               </v-col>
 
               <v-col cols="6" md="6">
@@ -32,6 +38,12 @@
                   :label="$t('dialogs.addElement.toNodeId')"
                   hide-details="auto"
                   required
+                />
+                <v-checkbox-btn
+                  v-model="newElementHinges[1]"
+                  class="hinges"
+                  density="compact"
+                  :label="$t('elements.hinge')"
                 />
               </v-col>
             </v-row>
@@ -123,6 +135,8 @@ const open = ref(true);
 
 const newElementFrom = ref('');
 const newElementTo = ref('');
+/** End releases of the new element, in the order of the From / To nodes above. */
+const newElementHinges = ref([false, false]);
 const newElementMat = ref('');
 const newElementCS = ref('');
 
@@ -163,10 +177,20 @@ const addElement = () => {
   }
 
   executeModelMutationWithUndo(() => {
-    domain.createBeam2D(nid, [newElementFrom.value, newElementTo.value], newElementMat.value, newElementCS.value);
+    domain.createBeam2D(nid, [newElementFrom.value, newElementTo.value], newElementMat.value, newElementCS.value, [
+      ...newElementHinges.value,
+    ]);
     domain.elements = new Map(domain.elements);
   });
 
   closeModal();
 };
 </script>
+
+<style scoped>
+/* The hinge label reads as a caption of the node select above it, so it matches its floating label. */
+.hinges :deep(.v-label) {
+  font-size: 0.75em;
+  opacity: var(--v-medium-emphasis-opacity);
+}
+</style>

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -54,7 +54,8 @@
   "elements": {
     "addElement": "添加单元",
     "editElement": "编辑单元",
-    "swapNodeOrder": "交换节点顺序"
+    "swapNodeOrder": "交换节点顺序",
+    "hinge": "铰接"
   },
   "loads": {
     "addNodalLoad": "添加节点荷载",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -117,7 +117,8 @@
   "elements": {
     "addElement": "Přidat prvek",
     "swapNodeOrder": "Přehodit pořadí uzlů",
-    "editElement": "Upravit prvek"
+    "editElement": "Upravit prvek",
+    "hinge": "Kloub"
   },
   "loads": {
     "addElementLoad": "Přidat prvkové zatížení",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -54,7 +54,8 @@
   "elements": {
     "addElement": "Element hinzufügen",
     "editElement": "Element bearbeiten",
-    "swapNodeOrder": "Knotenreihenfolge tauschen"
+    "swapNodeOrder": "Knotenreihenfolge tauschen",
+    "hinge": "Gelenk"
   },
   "loads": {
     "addNodalLoad": "Knotenlast hinzufügen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -54,7 +54,8 @@
   "elements": {
     "addElement": "Add element",
     "editElement": "Edit element",
-    "swapNodeOrder": "Swap nodes"
+    "swapNodeOrder": "Swap nodes",
+    "hinge": "Hinge"
   },
   "loads": {
     "addNodalLoad": "Add nodal load",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -54,7 +54,8 @@
   "elements": {
     "addElement": "Añadir elemento",
     "editElement": "Editar elemento",
-    "swapNodeOrder": "Intercambiar nodos"
+    "swapNodeOrder": "Intercambiar nodos",
+    "hinge": "Rótula"
   },
   "loads": {
     "addNodalLoad": "Añadir carga nodal",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -54,7 +54,8 @@
   "elements": {
     "addElement": "Ajouter un élément",
     "editElement": "Modifier l'élément",
-    "swapNodeOrder": "Inverser les nœuds"
+    "swapNodeOrder": "Inverser les nœuds",
+    "hinge": "Rotule"
   },
   "loads": {
     "addNodalLoad": "Ajouter une charge nodale",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -54,7 +54,8 @@
   "elements": {
     "addElement": "Dodaj element",
     "editElement": "Edytuj element",
-    "swapNodeOrder": "Zamień kolejność węzłów"
+    "swapNodeOrder": "Zamień kolejność węzłów",
+    "hinge": "Przegub"
   },
   "loads": {
     "addNodalLoad": "Dodaj obciążenie węzłowe",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -54,7 +54,8 @@
   "elements": {
     "addElement": "Adicionar elemento",
     "editElement": "Editar elemento",
-    "swapNodeOrder": "Inverter nós"
+    "swapNodeOrder": "Inverter nós",
+    "hinge": "Rótula"
   },
   "loads": {
     "addNodalLoad": "Adicionar carga nodal",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -54,7 +54,8 @@
   "elements": {
     "addElement": "Добавить элемент",
     "editElement": "Редактировать элемент",
-    "swapNodeOrder": "Поменять порядок узлов"
+    "swapNodeOrder": "Поменять порядок узлов",
+    "hinge": "Шарнир"
   },
   "loads": {
     "addNodalLoad": "Добавить узловую нагрузку",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -53,7 +53,8 @@
   "elements": {
     "addElement": "เพิ่มองค์ประกอบ",
     "editElement": "แก้ไของค์ประกอบ",
-    "swapNodeOrder": "สลับโหนด"
+    "swapNodeOrder": "สลับโหนด",
+    "hinge": "จุดหมุน"
   },
   "loads": {
     "addNodalLoad": "เพิ่มแรงกระทำที่โหนด",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -54,7 +54,8 @@
   "elements": {
     "addElement": "Додати елемент",
     "editElement": "Редагувати елемент",
-    "swapNodeOrder": "Поміняти порядок вузлів"
+    "swapNodeOrder": "Поміняти порядок вузлів",
+    "hinge": "Шарнір"
   },
   "loads": {
     "addNodalLoad": "Додати вузлове навантаження",


### PR DESCRIPTION
Closes #1015 — end hinges can now be set where the element is defined, in the canvas context menu and in the Add element dialog.

## Problem

End releases can only be changed in the elements table. They are missing from both places where an element is otherwise defined — the canvas context menu and the add dialog — so setting a hinge means creating the element, then hunting for its row in the bottom bar. Issue #1015.

## Change

A `Hinge` checkbox under each node select, in both places:

- **Edit element** in the canvas context menu — under the From / To selects.
- **Add element** dialog — the same pair, applied when the element is created.

<img width="388" height="176" alt="image" src="https://github.com/user-attachments/assets/d6efdc9e-7cd8-4fd2-bccb-44a5b339c5af" />

<img width="396" height="295" alt="image" src="https://github.com/user-attachments/assets/f2d0371d-a404-4c28-8786-b3cc04c671b1" />

- The label is just `Hinge`: the column above already says which end it belongs to, and a short word fits the 90px column.