### PR TITLE
fix: numeric field rules throw on a number, and reject a decimal comma

### DIFF
--- a/src/components/settings/Appearance.vue
+++ b/src/components/settings/Appearance.vue
@@ -54,14 +54,15 @@
       </v-row>
 
       <v-text-field
-        v-model.number="viewerStore.gridStep"
+        v-model="gridStepInput"
         :label="$t('settings.grid_snap_step')"
         :rules="positiveNumberRules"
         hide-details="auto"
-        type="number"
-        min="0.001"
-        step="0.001"
+        inputmode="decimal"
         suffix="m"
+        @keydown="checkNumber($event)"
+        @change="commitGridStep"
+        @blur="commitGridStep"
       />
 
       <h3 class="mt-3 mb-2">{{ $t('settings.result_labels') }}</h3>
@@ -285,11 +286,32 @@
 import { useViewerStore } from '@/store/viewer';
 import SVGElementViewer from '../SVGElementViewer.vue';
 import { LinearStaticSolver, DofID } from 'ts-fem';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { positiveNumberRules } from '@/utils';
+import { checkNumber, parseFloat2, positiveNumberRules } from '@/utils';
 
 const viewerStore = useViewerStore();
+
+/**
+ * Edited as text rather than `type="number"`: a decimal comma, which is what a phone keyboard
+ * offers in most locales, leaves a number input empty and the field then complains that nothing
+ * was entered. The store keeps a number, so the text is parsed on change.
+ */
+const gridStepInput = ref(String(viewerStore.gridStep));
+
+watch(
+  () => viewerStore.gridStep,
+  (step) => {
+    if (parseFloat2(gridStepInput.value) !== step) gridStepInput.value = String(step);
+  }
+);
+
+const commitGridStep = () => {
+  const step = parseFloat2(gridStepInput.value);
+  if (!Number.isFinite(step) || step <= 0) return;
+
+  viewerStore.gridStep = step;
+};
 const showQuantity = ref('deformedShape');
 const { t } = useI18n();
 

--- a/src/tests/numberRules.test.ts
+++ b/src/tests/numberRules.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { numberRules, positiveNumberRules } from '../utils';
+
+const check = (rules: ((v: unknown) => unknown)[], v: unknown) =>
+  rules.map((r) => r(v)).find((r) => r !== true) ?? true;
+
+describe('numeric field rules', () => {
+  it('accepts the number a `v-model.number` field holds', () => {
+    expect(check(numberRules, 0.5)).toBe(true);
+    expect(check(positiveNumberRules, 0.5)).toBe(true);
+  });
+
+  it('accepts strings, including a decimal comma', () => {
+    expect(check(numberRules, '0,5')).toBe(true);
+    expect(check(numberRules, '1e5')).toBe(true);
+    expect(check(numberRules, ' 12 ')).toBe(true);
+  });
+
+  it('rejects empty, junk and non positive values', () => {
+    expect(check(numberRules, '')).not.toBe(true);
+    expect(check(numberRules, null)).not.toBe(true);
+    expect(check(numberRules, '5abc')).not.toBe(true);
+    expect(check(numberRules, NaN)).not.toBe(true);
+    expect(check(positiveNumberRules, 0)).not.toBe(true);
+    expect(check(positiveNumberRules, -3)).not.toBe(true);
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -491,14 +491,29 @@ export const changeRefNumValue = (value: string) => {
   return val;
 };
 
+/**
+ * A field hands its rules whatever its model holds: a string, or a number where the template uses
+ * `v-model.number`. Returns NaN for anything that is not a number, so the rules can tell the two
+ * failure cases apart.
+ */
+const ruleValueAsNumber = (v: unknown) => {
+  if (typeof v === 'number') return v;
+  if (typeof v !== 'string') return NaN;
+
+  const normalized = v.replace(/\s/g, '').replace(',', '.');
+  if (normalized === '') return NaN;
+
+  // Number(), not parseFloat(): trailing junk like "5abc" has to stay invalid
+  return Number(normalized);
+};
+
+const isEmptyRuleValue = (v: unknown) => v === '' || v === null || v === undefined;
+
 export const numberRules = [
-  (v: string) => {
-    if (v === '') return i18n.global.t('validators.enterValue');
+  (v: unknown) => {
+    if (isEmptyRuleValue(v)) return i18n.global.t('validators.enterValue');
 
-    const tmp = v.replace(/\s/g, '').replace(',', '.');
-
-    // isNaN accepts a string, the types are wrong
-    if (isNaN(tmp as unknown as number)) return i18n.global.t('validators.invalidNumber');
+    if (!Number.isFinite(ruleValueAsNumber(v))) return i18n.global.t('validators.invalidNumber');
 
     return true;
   },
@@ -507,8 +522,8 @@ export const numberRules = [
 /** Like `numberRules`, but additionally requires a finite value strictly greater than zero. */
 export const positiveNumberRules = [
   ...numberRules,
-  (v: string) => {
-    const val = parseFloat(v.replace(/\s/g, '').replace(',', '.'));
+  (v: unknown) => {
+    const val = ruleValueAsNumber(v);
     if (!Number.isFinite(val) || val <= 0) return i18n.global.t('validators.positiveNumber');
 
     return true;


### PR DESCRIPTION
## Problem

Two bugs in the "Grid snap step" field of Viewer settings, both from the way it is bound — it is the only input in the app using `v-model.number` with `type="number"`.

- **`v.replace is not a function`** on every keystroke. `numberRules` and `positiveNumberRules` assumed a string: `v.replace(/\s/g, '').replace(',', '.')`. Every other field feeds them a string, so it never surfaced before.
- **"Enter a value" while typing.** `type="number"` discards a decimal **comma** — the separator a phone keyboard offers in most locales — so the browser hands back an empty value and the field complains that nothing was entered.

## Change

- Both rule sets take the value as it comes, through a shared `ruleValueAsNumber()`: a number passes straight through, a string is normalised as before. Strictness is unchanged — it still uses `Number()` rather than `parseFloat()`, so `"5abc"` stays invalid while `"1e5"`, `" 12 "` and `"0,5"` stay valid.
- The grid step field becomes a text input with `inputmode="decimal"` (still a numeric keypad on a phone), backed by a string ref that is parsed into `viewerStore.gridStep` on change and blur via the existing `parseFloat2`, which already accepts a comma. A watcher keeps the text in sync when the store changes elsewhere, e.g. on settings reset. This matches how every other numeric field in the app works.

## Testing

`src/tests/numberRules.test.ts` covers the rules directly: a raw number passes — the case that threw — comma, exponent and whitespace strings pass, and empty, `null`, `"5abc"`, `NaN`, `0` and negatives are rejected.

`npm run test:run` — 134 passed. `npx vite build` ok. `npm run lint` reports no new problems.

Worth checking on a device: typing `0,5` into grid step commits instead of clearing the field.
