### PR TITLE
fix: show the grid and snap toggles at every window size

### DIFF
--- a/src/components/SVGViewer.vue
+++ b/src/components/SVGViewer.vue
@@ -5,7 +5,6 @@ import SvgGrid from './SVGGrid.vue';
 import SvgViewerDefs from './SVGViewerDefs.vue';
 import { useProjectStore } from '../store/project';
 import { ref, onMounted, computed, nextTick, watch, reactive, onUnmounted, provide } from 'vue';
-import { useDisplay } from 'vuetify';
 import { useViewerStore } from '../store/viewer';
 import { useAppStore } from '@/store/app';
 
@@ -79,8 +78,6 @@ const props = defineProps<{
   id: string;
   resultLabelMode?: 'axis' | 'horizontal';
 }>();
-
-const { mobile } = useDisplay();
 
 let mouseStartX = 0;
 let mouseStartY = 0;
@@ -1679,7 +1676,7 @@ defineExpose({ centerContent, fitContent });
       class="text-body-2 d-flex ga-1 line-height-1"
       style="position: absolute; z-index: 100; bottom: 16px; right: 16px"
     >
-      <div v-if="!mobile" class="d-flex align-center ga-1">
+      <div class="d-flex align-center ga-1">
         <v-chip density="compact" class="d-flex pa-0 overflow-hidden">
           <!-- Grid toggle -->
           <v-tooltip text="Toggle grid (G)" location="top">


### PR DESCRIPTION
## Problem

The grid (`G`) and snap-to-grid (`S`) toggles in the bottom-right of the viewer are wrapped in `v-if="!mobile"`.

Vuetify's default `mobileBreakpoint` is **`lg`, i.e. 1280px** — not a phone-sized threshold. So the toggles disappear from any browser window narrower than that, and never appear on a phone. In practice they only show when the window is maximized on a wide screen, which makes them look like a fullscreen-only feature.

Touch is where they are needed most: the `G` and `S` keyboard shortcuts are out of reach there, so hiding the buttons leaves no way to toggle snapping at all.

## Change

The wrapper renders unconditionally. The toggles are two 24px buttons next to the units chip, so width was never the real constraint. `useDisplay` is no longer used in this component and was removed.

The bar as a whole is still hidden in viewer mode (`v-if="!appStore.inViewerMode"` on the parent), which is intended.

## Testing

Manual: the G and S chips are present in a narrow window and on a phone, and toggling them still drives grid visibility and snapping.
