### PR TITLE
fix: element preview in stiffness matrix preview

### DIFF
--- a/src/components/SVGElementViewer.vue
+++ b/src/components/SVGElementViewer.vue
@@ -227,7 +227,23 @@ const fitReserve = computed(
   () => props.fitReservePx ?? Math.max(props.resultsScalePx, LOAD_DECORATION_PX) + props.fontSize + 8
 );
 
-const modelBounds = () => boundsFromPoints(props.nodes.map((node) => [node.coords[0], node.coords[2]] as const));
+/**
+ * Endpoints of everything drawn. Elements are included because a preview can be given elements
+ * without their nodes (the widget header does), and a fit with no bounds falls back to measuring
+ * the rendered SVG - decorations sized from the not yet fitted scale included.
+ */
+const modelBounds = () => {
+  const points = props.nodes.map((node) => [node.coords[0], node.coords[2]] as const);
+
+  for (const element of props.elements) {
+    for (const label of element.nodes) {
+      const node = element.domain.nodes.get(label);
+      if (node) points.push([node.coords[0], node.coords[2]] as const);
+    }
+  }
+
+  return boundsFromPoints(points);
+};
 
 const onUpdate = throttle((zooming: boolean) => {
   if (grid.value) grid.value.refreshGrid(zooming);

--- a/src/components/svg/Element.vue
+++ b/src/components/svg/Element.vue
@@ -129,24 +129,35 @@ const elementLabel = computed(() => {
   return `translate(${(-props.padding * nx) / props.scale}, ${(-props.padding * ny) / props.scale})`;
 });
 
+/** How far from its node a hinge circle sits, 9px unless the element is drawn shorter than that. */
+const HINGE_OFFSET_PX = 9;
+
+const hingeOffset = computed(() => {
+  const geo = props.element.computeGeo();
+
+  // In a small preview the element can be only a few pixels long, and an offset taken purely from
+  // the scale would put the circle past the far node - drawing the hinge at the wrong end.
+  return Math.min(HINGE_OFFSET_PX / props.scale, geo.l / 3);
+});
+
 const elementHinges = computed(() => {
   const n1 = props.element.domain.nodes.get(props.element.nodes[0]) as Node;
   const n2 = props.element.domain.nodes.get(props.element.nodes[1]) as Node;
 
   const geo = props.element.computeGeo();
-  const k1 = 1;
-  const k2 = -1;
+  const offset = hingeOffset.value;
 
-  const nx = ((geo.dx * 9) / geo.l / props.scale) * k1;
-  const nz = ((geo.dz * 9) / geo.l / props.scale) * k1;
+  const nx = (geo.dx / geo.l) * offset;
+  const nz = (geo.dz / geo.l) * offset;
+
   const line1 = `${n1.coords[0] + nx}, ${n1.coords[2] + nz}`;
-
-  const nx2 = ((geo.dx * 9) / geo.l / props.scale) * k2;
-  const nz2 = ((geo.dz * 9) / geo.l / props.scale) * k2;
-  const line2 = `${n2.coords[0] + nx2}, ${n2.coords[2] + nz2}`;
+  const line2 = `${n2.coords[0] - nx}, ${n2.coords[2] - nz}`;
 
   return { 0: line1, 1: line2 };
 });
+
+/** The circle has to stay inside the element too, for the same reason. */
+const hingeRadius = computed(() => Math.min(6 / props.scale, hingeOffset.value * (2 / 3)));
 
 const results = computed(() => {
   if (!props.loadCase.solved || !props.showDeformedShape) return '';
@@ -599,7 +610,7 @@ const emit = defineEmits(['elementmousemove', 'elementresultsmousemove', 'elemen
       <circle
         v-if="element.hinges[0]"
         :transform="`translate(${elementHinges[0]})`"
-        :r="6 / scale"
+        :r="hingeRadius"
         fill="white"
         stroke="black"
         vector-effect="non-scaling-stroke"
@@ -609,7 +620,7 @@ const emit = defineEmits(['elementmousemove', 'elementresultsmousemove', 'elemen
       <circle
         v-if="element.hinges[1]"
         :transform="`translate(${elementHinges[1]})`"
-        :r="6 / scale"
+        :r="hingeRadius"
         fill="white"
         stroke="black"
         vector-effect="non-scaling-stroke"

--- a/src/tests/hingeMarkers.test.ts
+++ b/src/tests/hingeMarkers.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { LinearStaticSolver } from 'ts-fem';
+import SVGElement from '../components/svg/Element.vue';
+
+const beam = (length: number, hinges: [boolean, boolean]) => {
+  const solver = new LinearStaticSolver();
+  const domain = solver.domain;
+
+  domain.createNode(1, [0, 0, 0], []);
+  domain.createNode(2, [length, 0, 0], []);
+  domain.createMaterial(1, { e: 1, g: 1, alpha: 0, d: 0 });
+  domain.createCrossSection(1, { a: 1, iy: 1, h: 1, k: 1 });
+  domain.createBeam2D(1, [1, 2], 1, 1, hinges);
+
+  return { solver, element: domain.getElement(1) };
+};
+
+const hingeX = (length: number, hinges: [boolean, boolean], scale: number) => {
+  const { solver, element } = beam(length, hinges);
+  const wrapper = mount(SVGElement, {
+    props: { element, scale, showGeometry: true, showResults: false, loadCase: solver.loadCases[0] },
+  });
+
+  return wrapper.findAll('circle').map((c) => Number(/translate\(([-\d.]+)/.exec(c.attributes('transform') ?? '')![1]));
+};
+
+describe('hinge markers', () => {
+  it('sits 9px inside the element it belongs to', () => {
+    expect(hingeX(4, [true, false], 10)).toEqual([0.9]);
+    expect(hingeX(4, [false, true], 10)).toEqual([4 - 0.9]);
+  });
+
+  it('stays inside the element when it is drawn only a few pixels long', () => {
+    // 9px at this scale would be 4.5 units - past the far node, drawing the hinge at the wrong end
+    const [start, end] = hingeX(4, [true, true], 2);
+
+    expect(start).toBeGreaterThan(0);
+    expect(start).toBeLessThan(end);
+    expect(end).toBeLessThan(4);
+  });
+});


### PR DESCRIPTION
## Problem

In the stiffness matrix widget, the element sketch in the header is not clear (looks like the circle is placed at the wrong end).
<img width="404" height="125" alt="image" src="https://github.com/user-attachments/assets/5ff5719d-75ff-4055-a40a-62c89c76d0cc" />

## Change

<img width="455" height="130" alt="image" src="https://github.com/user-attachments/assets/426b5a9a-1c0b-4424-b91a-d71eb4fec09a" />
